### PR TITLE
Add error handling to `api.diagnostics_line`

### DIFF
--- a/lua/lspsaga/api.lua
+++ b/lua/lspsaga/api.lua
@@ -5,7 +5,9 @@ M.methods = {
 }
 
 M.diagnostics_line = function(bufnr, winid)
-  return vim.diagnostic.get(bufnr, { lnum = vim.api.nvim_win_get_cursor(winid)[1] - 1 })
+  if vim['diagnostic'] ~= nil then
+    return vim.diagnostic.get(bufnr, { lnum = vim.api.nvim_win_get_cursor(winid)[1] - 1 })
+  end
 end
 
 M.code_action_request = function(args)


### PR DESCRIPTION
Add a check before attempting to reference `vim.diagnostic` in `api.diagnostic`.  This stops the error mentioned in Issue #22 