### PR TITLE
fix(api): replace vim.diagnostics.get function call

### DIFF
--- a/lua/lspsaga/api.lua
+++ b/lua/lspsaga/api.lua
@@ -4,15 +4,9 @@ M.methods = {
   code_action = "textDocument/codeAction",
 }
 
-M.diagnostics_line = function(bufnr, winid)
-  if vim['diagnostic'] ~= nil then
-    return vim.diagnostic.get(bufnr, { lnum = vim.api.nvim_win_get_cursor(winid)[1] - 1 })
-  end
-end
-
 M.code_action_request = function(args)
-  local winid, bufnr = (args.winid or vim.api.nvim_get_current_win()), vim.api.nvim_get_current_buf()
-  args.params.context = args.context or { diagnostics = M.diagnostics_line(bufnr, winid) }
+  local bufnr = vim.api.nvim_get_current_buf()
+  args.params.context = args.context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
   local callback = args.callback { bufnr = bufnr, method = M.methods.code_action, params = args.params }
   vim.lsp.buf_request_all(bufnr, M.methods.code_action, args.params, callback)
 end


### PR DESCRIPTION
Replaced the api diagnostics context from `vim.diagnostic.get` to `vim.lsp.diagnostic.get_line_diagnostics`.

This was done to fix the codeaction window that was not showing, like in the issue #24

[Reference](https://github.com/neovim/neovim/blob/966e605db96a9654af6b93bfccee4fbd23ed71a5/runtime/lua/vim/lsp/buf.lua#L567)