### PR TITLE
fix(codeaction.window): closing window before sending the request

### DIFF
--- a/lua/lspsaga/codeaction/window.lua
+++ b/lua/lspsaga/codeaction/window.lua
@@ -50,8 +50,10 @@ end
 M.execute = function()
   local choice = M.actions[tonumber(vim.fn.expand "<cword>")]
   if choice then
+    M.close()
     local client_id, action = choice[1], choice[2]
     api.code_action_execute(client_id, action, M.ctx)
+    return
   end
   M.close()
 end


### PR DESCRIPTION
This is meant to fix the issue #25 by preventing the vim api from choosing the current Lspsaga popup as the current buffer.