### PR TITLE
fix empty cursor_line_bg

### DIFF
--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -444,8 +444,8 @@ function Finder:clear_tmp_data()
   if self.cursor_line_bg ~= '' then
     api.nvim_command('hi! CursorLine  guibg='..self.cursor_line_bg)
   end
-  if self.cursor_line_fg == "" then
-    api.nvim_command "hi! CursorLine  guifg=NONE"
+  if self.cursor_line_fg == '' then
+    api.nvim_command('hi! CursorLine  guifg=NONE')
   end
 end
 

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -396,7 +396,9 @@ function Finder:clear_tmp_data()
   self.buf_filetype = ''
   self.WIN_HEIGHT = 0
   self.WIN_WIDTH = 0
-  api.nvim_command('hi! CursorLine  guibg='..self.cursor_line_bg)
+  if self.cursor_line_bg ~= '' then
+    api.nvim_command('hi! CursorLine  guibg='..self.cursor_line_bg)
+  end
   if self.cursor_line_fg == '' then
     api.nvim_command('hi! CursorLine  guifg=NONE')
   end


### PR DESCRIPTION
I'm using a colorscheme that does not have cursor line bg. I will get error:

```
Vim(highlight):E417: missing argument: guibg=
```

when I close the finder window