### PR TITLE
Added config option 'diagnostic_prefix_format' and fix show_header=false scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ lspsaga.setup { -- defaults ...
   border_style = "single",
   rename_prompt_prefix = "➤",
   server_filetype_map = {},
+  diagnostic_prefix_format = "%d. ",
 }
 ```
 ## Example Keymapings

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -59,7 +59,7 @@ local show_diagnostics = function(opts, get_diagnostics)
   end
 
   for i, diagnostic in ipairs(diagnostics) do
-    local prefix = config.prefix_diagnostic and string.format("%d. ", i) or ""  
+    local prefix = string.format(config.diagnostic_prefix_format, i)
     local hiname = M.highlights[diagnostic.severity]
     assert(hiname, "unknown severity: " .. tostring(diagnostic.severity))
 

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -88,7 +88,7 @@ local function show_diagnostics(opts, get_diagnostics)
     or diagnostics
 
   for i, diagnostic in ipairs(sorted_diagnostics) do
-    local prefix = string.format("%d. ", i)
+    local prefix = config.prefix_diagnostic and string.format("%d. ", i) or ""
     local hiname = lsp.diagnostic._get_floating_severity_highlight_name(diagnostic.severity)
     assert(hiname, 'unknown severity: ' .. tostring(diagnostic.severity))
 
@@ -107,8 +107,10 @@ local function show_diagnostics(opts, get_diagnostics)
   local wrap_message = wrap.wrap_contents(lines,max_width,{
     fill = true, pad_left = 3
   })
-  local truncate_line = wrap.add_truncate_line(wrap_message)
-  table.insert(wrap_message,2,truncate_line)
+  if show_header then
+    local truncate_line = wrap.add_truncate_line(wrap_message)
+    table.insert(wrap_message,2,truncate_line)
+  end
 
   local content_opts = {
     contents = wrap_message,

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -42,7 +42,7 @@ saga.config_values = {
   border_style = "single",
   rename_prompt_prefix = "➤",
   server_filetype_map = {},
-  prefix_diagnostic = true,
+  diagnostic_prefix_format = "%d. ",
 }
 
 saga.config_values.dianostic_header_icon = saga.config_values.diagnostic_header_icon

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -42,7 +42,7 @@ saga.config_values = {
   border_style = "single",
   rename_prompt_prefix = "➤",
   server_filetype_map = {},
-  prefix_diagnostic = true.
+  prefix_diagnostic = true,
 }
 
 saga.config_values.dianostic_header_icon = saga.config_values.diagnostic_header_icon

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -33,7 +33,8 @@ saga.config_values = {
   definition_preview_icon = '  ',
   border_style = "single",
   rename_prompt_prefix = '➤',
-  server_filetype_map = {}
+  server_filetype_map = {},
+  prefix_diagnostic = true
 }
 
 local extend_config = function(opts)


### PR DESCRIPTION
Need to suppress a line when there is no header. Also give ability to customise prefix for diagnostic messages.