### PR TITLE
Rename Prompt Populate Value

### DIFF
--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -38,6 +38,7 @@ saga.config_values = {
     quit = "<C-c>",
     exec = "<CR>",
   },
+  rename_prompt_populate = true,
   definition_preview_icon = "  ",
   border_style = "single",
   rename_prompt_prefix = "➤",

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -64,6 +64,7 @@ local rename = function()
     highlight = "LspSagaRenameBorder",
   }
 
+  local current_name = vim.fn.expand "<cword>"
   local bufnr, winid = window.create_win_with_border(content_opts, opts)
   local saga_rename_prompt_prefix = api.nvim_create_namespace "lspsaga_rename_prompt_prefix"
   api.nvim_win_set_option(winid, "scrolloff", 0)
@@ -74,6 +75,12 @@ local rename = function()
   vim.fn.prompt_setprompt(bufnr, prompt_prefix)
   api.nvim_buf_add_highlight(bufnr, saga_rename_prompt_prefix, "LspSagaRenamePromptPrefix", 0, 0, #prompt_prefix)
   vim.cmd [[startinsert!]]
+
+  -- Populate prompt with current var name
+  if config.rename_prompt_populate then
+  vim.fn.feedkeys(current_name)
+  end
+
   api.nvim_win_set_var(0, unique_name, winid)
   api.nvim_command "autocmd QuitPre <buffer> ++nested ++once :silent lua require('lspsaga.rename').close_rename_win()"
   apply_action_keys()


### PR DESCRIPTION
Added config option `rename_prompt_populate` to have the rename prompt
begin with the current cursor word.

Set the config option default to true
- This is a common default for similar plugins and functionality
- It is easier to delete a word than it is to type it out