### PR TITLE
Use diagnostic_header_icon instead of dianostic_header_icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ lspsaga.setup { -- defaults ...
   warn_sign = "",
   hint_sign = "",
   infor_sign = "",
-  dianostic_header_icon = "   ",
+  diagnostic_header_icon = "   ",
   -- code action title icon
   code_action_icon = " ",
   code_action_prompt = {

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -1,4 +1,4 @@
--- lsp dianostic
+-- lsp diagnostic
 local window = require "lspsaga.window"
 local libs = require "lspsaga.libs"
 local wrap = require "lspsaga.wrap"
@@ -44,7 +44,7 @@ local show_diagnostics = function(opts, get_diagnostics)
   local lines = {}
   local highlights = {}
   if show_header then
-    lines[1] = config.dianostic_header_icon .. "Diagnostics:"
+    lines[1] = config.diagnostic_header_icon .. "Diagnostics:"
     highlights[1] = { 0, "LspSagaDiagnosticHeader" }
   end
 


### PR DESCRIPTION
The corrected name was not being used. Meaning you have to use the deprecated name, which prints an annoying deprecation warning every time :p.