### PR TITLE
fix: remove calls to lsp.util.close_preview_autocmd

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -95,7 +95,7 @@ local show_diagnostics = function(opts, get_diagnostics)
   end
 
   vim.api.nvim_buf_add_highlight(bufnr, -1, "LspSagaDiagnosticTruncateLine", 1, 0, -1)
-  vim.lsp.util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, winid)
+  libs.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, winid)
   vim.api.nvim_win_set_var(0, "show_line_diag_winids", winid)
 
   return winid

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -1,6 +1,7 @@
 local api, lsp, util = vim.api, vim.lsp, vim.lsp.util
 local window = require "lspsaga.window"
 local action = require "lspsaga.action"
+local libs = require 'lspsaga.libs'
 local npcall = vim.F.npcall
 local hover = {}
 
@@ -29,7 +30,7 @@ hover.handler = function(_, result, ctx, _)
     window.nvim_win_try_close()
     local bufnr, winid = window.fancy_floating_markdown(markdown_lines)
 
-    lsp.util.close_preview_autocmd({
+    libs.close_preview_autocmd({
       "CursorMoved",
       "BufHidden",
       "BufLeave",

--- a/lua/lspsaga/implement.lua
+++ b/lua/lspsaga/implement.lua
@@ -65,7 +65,7 @@ function implement.lspsaga_implementation(timeout_ms)
     }
 
     local bf, wi = window.create_win_with_border(content_opts, opts)
-    vim.lsp.util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, wi)
+    libs.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, wi)
     vim.api.nvim_buf_add_highlight(bf, -1, "DefinitionPreviewTitle", 0, 0, -1)
 
     api.nvim_buf_set_var(0, "lspsaga_implement_preview", { wi, 1, config.max_preview_lines, 10 })

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -147,4 +147,10 @@ function libs.apply_keys(ns, actions)
   end
 end
 
+function libs.close_preview_autocmd(events, winid)
+  local events_str = table.concat(events, ',')
+  local cmd = string.format('autocmd %s <buffer> ++once lua pcall(vim.api.nvim_win_close, %d, true)', events_str, winid)
+  vim.api.nvim_command(cmd)
+end
+
 return libs

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -564,7 +564,7 @@ function lspfinder.preview_definition(timeout_ms)
         }
 
         local bf, wi = window.create_win_with_border(content_opts, opts)
-        vim.lsp.util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, wi)
+        libs.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, wi)
         vim.api.nvim_buf_add_highlight(bf, -1, "DefinitionPreviewTitle", 0, 0, -1)
 
         api.nvim_buf_set_var(0, "lspsaga_def_preview", { wi, 1, config.max_preview_lines, 10 })

--- a/lua/lspsaga/signaturehelp.lua
+++ b/lua/lspsaga/signaturehelp.lua
@@ -114,7 +114,7 @@ local function focusable_preview(unique_name, fn)
     api.nvim_set_current_win(winid)
     apply_syntax_to_region(filetype, 1, wrap_index)
     api.nvim_set_current_win(cwin)
-    util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, winid)
+    libs.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, winid)
     return bufnr, winid
   end)
 end


### PR DESCRIPTION
removed in neovim master
~PS: i would've made an util function but there seem to be no util(s) module so i did not add one. I can refactor this out somewhere else if you can point it out to me :)~