### PR TITLE
Code actions for multiple lsps are correctly numbered.

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -10,10 +10,12 @@ local on_code_action_response = function(ctx)
   window.content, window.actions = { window.title }, {}
 
   return function(response)
+    local actionNum = 1
     for client_id, result in pairs(response or {}) do
-      for index, action in ipairs(result.result or {}) do
+      for _, action in ipairs(result.result or {}) do
         table.insert(window.actions, { client_id, action })
-        table.insert(window.content, "[" .. index .. "]" .. " " .. action.title)
+        table.insert(window.content, "[" .. actionNum .. "]" .. " " .. action.title)
+        actionNum = actionNum + 1
       end
     end
 


### PR DESCRIPTION
Fixes #44

The code in `lua/lspsaga/codeaction/window.lua` uses the word (number) under the cursor to lookup which action to execute (_the actions are in a 1-based lua array, so that index can be used directly_):

https://github.com/tami5/lspsaga.nvim/blob/main/lua/lspsaga/codeaction/window.lua#L51-L58

This change ensures the words (numbers) that can be under the cursor are correctly incremented for each new action that is inserted into the `window.actions` table.

**Before**

![Screenshot from 2022-02-01 12-19-43](https://user-images.githubusercontent.com/612020/151899244-c9c83508-b783-4b68-baa1-793de7475aed.png)


**After**

![Screenshot from 2022-02-01 12-20-32](https://user-images.githubusercontent.com/612020/151899305-45ddf97e-ca07-4bde-a08c-18895bb1c42a.png)
