### PR TITLE
fix(code_action.indicator): detection of code_action capability

### DIFF
--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -68,7 +68,7 @@ M.check = function()
   if M.servers[current_file] == nil then
     local clients = vim.lsp.get_active_clients()
     for _, client in ipairs(clients) do
-      if client.resolved_capabilities.code_actions then
+      if client.resolved_capabilities.code_action then
         M.servers[current_file] = true
         break
       end


### PR DESCRIPTION
When rendering the code action indicator it early returns when the `code_action` capability is not supported by the current LSP. However, it incorrectly tries to detect it as `code_actions` (plural) instead of `code_action`:

![Screenshot 2022-02-01 at 09 18 05](https://user-images.githubusercontent.com/902842/151934135-71681246-cb92-4b01-aeb8-2881d9860c6f.png)

After fix:

![Screenshot 2022-02-01 at 09 19 51](https://user-images.githubusercontent.com/902842/151934342-eef47a21-4805-4693-b610-4cdeb5e5214e.png)

