### PR TITLE
feat(rename): add filetype

### DIFF
--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -59,7 +59,7 @@ local rename = function()
 
   local content_opts = {
     contents = {},
-    filetype = "",
+    filetype = "LspSagaRename",
     enter = true,
     highlight = "LspSagaRenameBorder",
   }

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -59,7 +59,7 @@ local rename = function()
 
   local content_opts = {
     contents = {},
-    filetype = "LspSagaRename",
+    filetype = "LspsagaRename",
     enter = true,
     highlight = "LspSagaRenameBorder",
   }


### PR DESCRIPTION
I want to add a filetype to rename because I want to add a keymap in the buffer of rename.

```vim
function! s:lspsaga_rename() abort
  nnoremap <buffer> <Esc> q
  inoremap <buffer> <C-o> <C-r>+
  inoremap <buffer> <C-w> <C-S-W>
endfunction
augroup my-lspsaga
  autocmd!
  autocmd FileType LspSagaRename call s:lspsaga_rename()
augroup END
```

There are several possible names for the filetype, which one do you prefer?

* `lspsagarename`
* `LspSagaRename`
* `LspsagaRename`
