### PR TITLE
feat(rename): optional integration of quickfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ lspsaga.setup { -- defaults ...
   definition_preview_icon = "  ",
   border_style = "single",
   rename_prompt_prefix = "➤",
+  rename_output_qflist = false,
   server_filetype_map = {},
   diagnostic_prefix_format = "%d. ",
   diagnostic_message_format = "%m %c",

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ lspsaga.setup { -- defaults ...
   definition_preview_icon = "  ",
   border_style = "single",
   rename_prompt_prefix = "➤",
-  rename_output_qflist = false,
+  rename_output_qflist = {
+    enable = false,
+    auto_open_qflist = false,
+  },
   server_filetype_map = {},
   diagnostic_prefix_format = "%d. ",
   diagnostic_message_format = "%m %c",

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -39,7 +39,10 @@ saga.config_values = {
     exec = "<CR>",
   },
   rename_prompt_populate = true,
-  rename_output_qflist = false,
+  rename_output_qflist = {
+    enable = false,
+    auto_open_qflist = false,
+  },
   definition_preview_icon = "  ",
   border_style = "single",
   rename_prompt_prefix = "➤",

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -39,6 +39,7 @@ saga.config_values = {
     exec = "<CR>",
   },
   rename_prompt_populate = true,
+  rename_output_qflist = false,
   definition_preview_icon = "  ",
   border_style = "single",
   rename_prompt_prefix = "➤",

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -116,7 +116,7 @@ local rename_handler = function(_, result, ctx, _)
     if #locations == 0 then
       return
     else
-      vim.fn.setqflist(vim.lsp.util.locations_to_items(locations, offset_encoding))
+      vim.fn.setqflist(vim.lsp.util.locations_to_items(locations, offset_encoding), ' ')
     end
   end
 end

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -110,13 +110,16 @@ local rename_handler = function(_, result, ctx, _)
   local client = vim.lsp.get_client_by_id(ctx.client_id)
   util.apply_workspace_edit(result, client.offset_encoding)
 
-  if config.rename_output_qflist then
+  if config.rename_output_qflist.enable then
     local offset_encoding = vim.lsp.get_client_by_id(ctx.client_id).offset_encoding
     local locations = workspaceedit_changes_to_location_list(result.changes)
     if #locations == 0 then
       return
     else
       vim.fn.setqflist(vim.lsp.util.locations_to_items(locations, offset_encoding), ' ')
+      if config.rename_output_qflist.auto_open_qflist then
+        vim.cmd "copen"
+      end
     end
   end
 end


### PR DESCRIPTION
Since [renamer.nvim](https://github.com/filipdutescu/renamer.nvim) used to output to quickfix list, I added a similar feature.
I added an `rename_output_qflist`option, but it defaults to `false`, so you need to set it to true to enable it.
I will describe the options in the wiki, is that OK?