### PR TITLE
Remap code-action example maps to gX

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ lspsaga.setup { -- defaults ...
 --- In lsp attach function
 local map = nvim_buf_set_keymap,
 map(0, "n", "gr", "<cmd>Lspsaga rename<cr>", {silent = true, noremap = true})
-map(0, "n", "gx", "<cmd>Lspsaga code_action<cr>", {silent = true, noremap = true})
-map(0, "x", "gx", ":<c-u>Lspsaga range_code_action<cr>", {silent = true, noremap = true})
+map(0, "n", "gX", "<cmd>Lspsaga code_action<cr>", {silent = true, noremap = true})
+map(0, "x", "gX", ":<c-u>Lspsaga range_code_action<cr>", {silent = true, noremap = true})
 map(0, "n", "K",  "<cmd>Lspsaga hover_doc<cr>", {silent = true, noremap = true})
 map(0, "n", "go", "<cmd>Lspsaga show_line_diagnostics<cr>", {silent = true, noremap = true})
 map(0, "n", "gj", "<cmd>Lspsaga diagnostic_jump_next<cr>", {silent = true, noremap = true})


### PR DESCRIPTION
As I re-enabled lspsaga range_code_action after https://github.com/tami5/lspsaga.nvim/issues/44 I noticed that the keymap `gx` in normal was being overridden by netrwBrowseX from the nvim-built-in netrw.vim plugin, my config is:

```
local on_attach = function(client, bufnr)
  local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
  local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end

  -- Enable completion triggered by <c-x><c-o>
  buf_set_option('omnifunc', 'v:lua.vim.lsp.omnifunc')

  -- Mappings.
  local noopts = {}
  local opts = { noremap=true, silent=true }

  -- Fancy lspsaga things
  buf_set_keymap("n", "gh", "<cmd>Lspsaga lsp_finder<cr>", noopts)
  buf_set_keymap("n", "gr", "<cmd>Lspsaga rename<cr>", opts)
  buf_set_keymap("n", "gx", "<cmd>Lspsaga code_action<cr>", opts)
  buf_set_keymap("x", "gx", ":<c-u>Lspsaga range_code_action<cr>", opts)
  buf_set_keymap("x", "gx", ":<c-u>Lspsaga range_code_action<cr>", opts)
  buf_set_keymap("n", "K",  "<cmd>Lspsaga hover_doc<cr>", opts)
  buf_set_keymap("n", "go", "<cmd>Lspsaga show_line_diagnostics<cr>", opts)
  buf_set_keymap("n", "gj", "<cmd>Lspsaga diagnostic_jump_next<cr>", opts)
  buf_set_keymap("n", "gk", "<cmd>Lspsaga diagnostic_jump_prev<cr>", opts)
  buf_set_keymap("n", "<C-u>", "<cmd>lua require('lspsaga.action').smart_scroll_with_saga(-1)<cr>", noopts)
  buf_set_keymap("n", "<C-d>", "<cmd>lua require('lspsaga.action').smart_scroll_with_saga(1)<cr>", noopts)
  -- non-fancy things
  -- buf_set_keymap('n', 'gx', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts) 
  buf_set_keymap('n', '<space>f', '<cmd>lua vim.lsp.buf.formatting()<CR>', opts) -- format things and autofix
  buf_set_keymap('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', opts) -- go to definition
  buf_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts) -- Check where definition under curos is implemented
end
```

Strangely when I comment the "Lspsaga code_action" line and uncomment `map('n', 'gx', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)` everything works as it should (i'm getting the ugly default lsp view though and not the pretty pop-up), there might be some kind of order thing going on somewhere.

I am working around this problem by assigning the key-map to gX instead and respecting the default VIM mapping for netrw.
 
If anyone runs into problems (getting the error `**warning** (netrw) shell signalled an error` from netrw) then check if the line below is in your `:map` and override the override or remap as per my example in the readme ;). 

```
:map

...
n  gx            NetrwBrowseX
...
```

Opening a pull request to propose gX as the new default as I'll probably wont be the only person running in to this problem with `neovim v0.6.1`