### PR TITLE
enh(actions.indicator): rework

### DIFF
--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -64,18 +64,16 @@ end
 M.check = function()
   local active, _ = libs.check_lsp_active()
   local current_file = vim.fn.expand "%:p"
-  local is_file = vim.loop.fs_stat(current_file) ~= nil
-  local fb = vim.bo.filetype
+  if vim.loop.fs_stat(current_file) == nil then -- current_file is not a file
+    M.servers[current_file] = false
+    return
+  end
 
   if M.servers[current_file] == nil then
     vim.lsp.for_each_buffer_client(vim.api.nvim_get_current_buf(), function(client)
         if M.servers[current_file] then return end
         if
-          is_file
-          and client
-          and client.config.filetypes
-          and vim.tbl_contains(client.config.filetypes, fb)
-          and client.resolved_capabilities.code_action
+          client.resolved_capabilities.code_action
           and client.supports_method "code_action"
         then
           M.servers[current_file] = true

--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -63,9 +63,12 @@ end
 
 M.check = function()
   local active, _ = libs.check_lsp_active()
-  local current_file = vim.fn.expand "%:p"
-  if vim.loop.fs_stat(current_file) == nil then -- current_file is not a file
-    M.servers[current_file] = false
+  local current_file = vim.api.nvim_buf_get_name(0)
+  local is_file = vim.loop.fs_stat(current_file) ~= nil
+
+  if not active or not is_file or M.special_buffers[vim.bo.filetype] then
+    -- Lsp could become active after some time so we should not
+    -- use `M.server[current_file] = false` here
     return
   end
 
@@ -86,7 +89,7 @@ M.check = function()
     end
   end
 
-  if M.special_buffers[vim.bo.filetype] or not active or M.servers[current_file] == false then
+  if M.servers[current_file] == false then
     return
   end
 

--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -68,21 +68,20 @@ M.check = function()
   local fb = vim.bo.filetype
 
   if M.servers[current_file] == nil then
-    local clients = vim.lsp.get_active_clients()
-
-    for _, client in ipairs(clients) do
-      if
-        is_file
-        and client
-        and client.config.filetypes
-        and vim.tbl_contains(client.config.filetypes, fb)
-        and client.resolved_capabilities.code_action
-        and client.supports_method "code_action"
-      then
-        M.servers[current_file] = true
-        break
+    vim.lsp.for_each_buffer_client(vim.api.nvim_get_current_buf(), function(client)
+        if M.servers[current_file] then return end
+        if
+          is_file
+          and client
+          and client.config.filetypes
+          and vim.tbl_contains(client.config.filetypes, fb)
+          and client.resolved_capabilities.code_action
+          and client.supports_method "code_action"
+        then
+          M.servers[current_file] = true
+        end
       end
-    end
+    )
 
     if M.servers[current_file] == nil then
       M.servers[current_file] = false


### PR DESCRIPTION
Fix #67 
When I open some python file and then open some another python file I have the error 
```
Error detected while processing CursorHold Autocommands for "*":
method textDocument/codeAction is not supported by any of the servers registered for the current buffer
```
This is because nvim runs a new copy of lsp for each opened python file. So it seems wrong copy of pylsp gave `M.servers[current_file] = true`.

I think the code is definitely better now. But the thing I have doubts about is that after some time the condition 
```lua
        if
          is_file
          and client
          and client.config.filetypes
          and vim.tbl_contains(client.config.filetypes, fb)
          and client.resolved_capabilities.code_action
          and client.supports_method "code_action"
        then
```
becomes `true`. So lspsaga should retry to attach after some time.

Update:
Now lspsaga is able to attach to lsp even if it becomes active after some time after opening file.