### PR TITLE
feat(diagnostic): yank diagnostics messages

### DIFF
--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -15,6 +15,7 @@ local subcommands = {
   hover_doc = lsphover.render_hover_doc,
   show_cursor_diagnostics = diagnostic.show_cursor_diagnostics,
   show_line_diagnostics = diagnostic.show_line_diagnostics,
+  yank_line_diagnostics = diagnostic.yank_line_messages,
   diagnostic_jump_next = diagnostic.navigate "next",
   diagnostic_jump_prev = diagnostic.navigate "prev",
   code_action = codeaction.code_action,


### PR DESCRIPTION
Close #50.

Usage:
`:Lspsaga diagnostic_yank_messages` yanks the last messages to vim default registry (the same used by the `y` key).
`:Lspsaga diagnostic_yank_messages +` yanks the last messages to system's clipboard (any other registry can be used).

It's my first time playing with Neovim plugins and Lua, so feel free to correct me if i messed up.