### PR TITLE
Fixed error with multiline code actions 

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -13,8 +13,11 @@ local on_code_action_response = function(ctx)
     local actionNum = 1
     for client_id, result in pairs(response or {}) do
       for _, action in ipairs(result.result or {}) do
+        -- Remove newline characters so that nvim_buf_set_lines doesn't fail
+        local single_line_title = string.gsub(action.title, '\n.*', ' (...)')
+
         table.insert(window.actions, { client_id, action })
-        table.insert(window.content, "[" .. actionNum .. "]" .. " " .. action.title)
+        table.insert(window.content, "[" .. actionNum .. "]" .. " " .. single_line_title)
         actionNum = actionNum + 1
       end
     end


### PR DESCRIPTION
sumneko_lua sometimes responds with absurdly long multiline code actions, which makes `nvim_buf_set_lines` fail (throws "String cannot contain newlines")
It can be reproduced with the following code, hovering over `ev` and opening the codeactions buffer
```lua
local t = {
    on_reload = function (ev, bufnr)
        --
    end
}
```

Fixed it by limiting actions to a single line, I don't think it makes sense to attempt to show all of the response