### PR TITLE
#12 (lsp_finder) fix misplaced cursor

### DIFF
--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -70,16 +70,20 @@ function libs.result_isempty(res)
   end
   for _, v in pairs(res) do
     if next(v) == nil then
-      return true
+      goto continue
     end
     if not v.result then
-      return true
+      goto continue
     end
     if next(v.result) == nil then
-      return true
+      goto continue
     end
+    if next(v.result) ~= nil then
+      return false
+    end
+    ::continue::
   end
-  return false
+  return true
 end
 
 function libs.split_by_pathsep(text, start_pos)

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -35,7 +35,7 @@ local send_request = function(timeout)
   for i, response in ipairs(responses) do
     if type(response) == "table" then
       for _, res in pairs(response) do
-        if res.result then
+        if res.result and next(res.result) ~= nil then
           coroutine.yield(res.result, i)
         end
       end


### PR DESCRIPTION
Tries to fix #12. Since sources can define for themselves how an empty result can look like, there is a chance the feature will break again, since a failing empty result check is the cause of the problem. The code now supports the following 3 result variants:

```lua
{
  [1] = {},
  [2] = {
    result = {}
  },
  [3] = {
    result = {
      <proper result>
    }
  }
}
```