### PR TITLE
Replate client.resolved_capabilities to client.server_capabilities

### DIFF
--- a/lua/lspsaga/api.lua
+++ b/lua/lspsaga/api.lua
@@ -34,7 +34,7 @@ M.code_action_execute = function(client_id, action, ctx)
   if
     not action.edit
     and client
-    and type(client.server_capabilities.code_action) == "table"
+    and type(client.server_capabilities.codeActionProvider) == "table"
     and client.server_capabilities.codeActionProvider.resolveProvider
   then
     client.request("codeAction/resolve", action, function(err, resolved_action)

--- a/lua/lspsaga/api.lua
+++ b/lua/lspsaga/api.lua
@@ -35,7 +35,7 @@ M.code_action_execute = function(client_id, action, ctx)
     not action.edit
     and client
     and type(client.server_capabilities.code_action) == "table"
-    and client.server_capabilities.code_action.resolveProvider
+    and client.server_capabilities.codeActionProvider.resolveProvider
   then
     client.request("codeAction/resolve", action, function(err, resolved_action)
       if err then

--- a/lua/lspsaga/api.lua
+++ b/lua/lspsaga/api.lua
@@ -34,8 +34,8 @@ M.code_action_execute = function(client_id, action, ctx)
   if
     not action.edit
     and client
-    and type(client.resolved_capabilities.code_action) == "table"
-    and client.resolved_capabilities.code_action.resolveProvider
+    and type(client.server_capabilities.code_action) == "table"
+    and client.server_capabilities.code_action.resolveProvider
   then
     client.request("codeAction/resolve", action, function(err, resolved_action)
       if err then

--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -76,7 +76,7 @@ M.check = function()
     vim.lsp.for_each_buffer_client(vim.api.nvim_get_current_buf(), function(client)
         if M.servers[current_file] then return end
         if
-          client.resolved_capabilities.code_action
+          client.server_capabilities.code_action
           and client.supports_method "code_action"
         then
           M.servers[current_file] = true

--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -76,7 +76,7 @@ M.check = function()
     vim.lsp.for_each_buffer_client(vim.api.nvim_get_current_buf(), function(client)
         if M.servers[current_file] then return end
         if
-          client.server_capabilities.code_action
+          client.server_capabilities.codeActionProvider
           and client.supports_method "code_action"
         then
           M.servers[current_file] = true

--- a/lua/lspsaga/signaturehelp.lua
+++ b/lua/lspsaga/signaturehelp.lua
@@ -16,7 +16,7 @@ local function check_server_support_signaturehelp()
   end
   local clients = vim.lsp.buf_get_clients()
   for _, client in pairs(clients) do
-    if client.resolved_capabilities.signature_help == true then
+    if client.server_capabilities.signature_help == true then
       return true
     end
   end

--- a/lua/lspsaga/signaturehelp.lua
+++ b/lua/lspsaga/signaturehelp.lua
@@ -16,7 +16,7 @@ local function check_server_support_signaturehelp()
   end
   local clients = vim.lsp.buf_get_clients()
   for _, client in pairs(clients) do
-    if client.server_capabilities.signature_help == true then
+    if client.server_capabilities.signatureHelpProvider then
       return true
     end
   end


### PR DESCRIPTION
Replate `client.resolved_capabilities` to `client.server_capabilities`.

`client.resolved_capabilities` is deprecated.
- https://github.com/neovim/neovim/pull/17814